### PR TITLE
Refactored final state of address validation wizard. #6733

### DIFF
--- a/tests/test_party.py
+++ b/tests/test_party.py
@@ -265,7 +265,7 @@ class TestParty(unittest.TestCase):
                 session_id, start_state, end_state = self.AddrValWizard.create()
 
                 with self.assertRaises(UserError) as e:
-                    self.AddrValWizard(session_id).default_start(None)
+                    self.AddrValWizard(session_id).transition_init()
 
                 self.assertIn(
                     'Validation method is not selected', e.exception.message


### PR DESCRIPTION
* Introduced an `init` transition before the `start` state begins. The actual address validation is performed here, and if there is a perfect match, then the wizard skips directly to `done` state.
* Renamed `generate` to `update` transition.