### PR TITLE
Quantize package_weight to 2 decimal place #7160

### DIFF
--- a/sale.py
+++ b/sale.py
@@ -56,12 +56,13 @@ class Sale:
         """
         Returns sum of weight associated with package
         """
-        return sum(
+        weight = sum(
             map(
                 lambda line: line.get_weight(uom, silent=True),
                 self.lines
             )
         )
+        return weight.quantize(Decimal('0.01'))  # Quantize to 2 decimal place
 
     def add_shipping_line(self, shipment_cost, description):
         """

--- a/shipment.py
+++ b/shipment.py
@@ -100,12 +100,13 @@ class ShipmentOut:
         Returns sum of weight associated with each move line
         """
         weight_uom = self._get_weight_uom()
-        return sum(
+        weight = sum(
             map(
                 lambda move: move.get_weight(weight_uom, silent=True),
                 self.outgoing_moves
             )
         )
+        return weight.quantize(Decimal('0.01'))  # Quantize to 2 decimal place
 
     def allow_label_generation(self):
         """

--- a/tests/test_party.py
+++ b/tests/test_party.py
@@ -7,11 +7,6 @@
 """
 import sys
 import os
-DIR = os.path.abspath(os.path.normpath(os.path.join(
-    __file__, '..', '..', '..', '..', '..', 'trytond'
-)))
-if os.path.isdir(DIR):
-    sys.path.insert(0, os.path.dirname(DIR))
 import unittest
 from decimal import Decimal
 
@@ -19,6 +14,11 @@ import trytond.tests.test_tryton
 from trytond.tests.test_tryton import POOL, DB_NAME, USER, CONTEXT
 from trytond.transaction import Transaction
 from trytond.exceptions import UserError
+DIR = os.path.abspath(os.path.normpath(os.path.join(
+    __file__, '..', '..', '..', '..', '..', 'trytond'
+)))
+if os.path.isdir(DIR):
+    sys.path.insert(0, os.path.dirname(DIR))
 
 
 class TestParty(unittest.TestCase):

--- a/tests/test_shipping.py
+++ b/tests/test_shipping.py
@@ -7,11 +7,6 @@
 """
 import sys
 import os
-DIR = os.path.abspath(os.path.normpath(os.path.join(
-    __file__, '..', '..', '..', '..', '..', 'trytond'
-)))
-if os.path.isdir(DIR):
-    sys.path.insert(0, os.path.dirname(DIR))
 import unittest
 from datetime import date
 from decimal import Decimal
@@ -20,6 +15,11 @@ import trytond.tests.test_tryton
 from trytond.tests.test_tryton import POOL, DB_NAME, USER, CONTEXT
 from trytond.transaction import Transaction
 from trytond.exceptions import UserError
+DIR = os.path.abspath(os.path.normpath(os.path.join(
+    __file__, '..', '..', '..', '..', '..', 'trytond'
+)))
+if os.path.isdir(DIR):
+    sys.path.insert(0, os.path.dirname(DIR))
 
 
 class TestShipping(unittest.TestCase):

--- a/tests/test_views_depends.py
+++ b/tests/test_views_depends.py
@@ -7,15 +7,15 @@
 """
 import sys
 import os
+import unittest
+
+import trytond.tests.test_tryton
+from trytond.tests.test_tryton import test_view, test_depends
 DIR = os.path.abspath(os.path.normpath(os.path.join(
     __file__, '..', '..', '..', '..', '..', 'trytond'
 )))
 if os.path.isdir(DIR):
     sys.path.insert(0, os.path.dirname(DIR))
-import unittest
-
-import trytond.tests.test_tryton
-from trytond.tests.test_tryton import test_view, test_depends
 
 
 class TestViewsDepends(unittest.TestCase):


### PR DESCRIPTION
Quantize package_weight to 2 decimal, else Numeric field may result in
   dirty field in tryton client, on client side roundoff.