### PR TITLE
Quantize package_weight to 2 decimal place #7160

### DIFF
--- a/sale.py
+++ b/sale.py
@@ -74,12 +74,13 @@ class Sale:
         """
         Returns sum of weight associated with package
         """
-        return sum(
+        weight = Decimal(sum(
             map(
                 lambda line: line.get_weight(uom, silent=True),
                 self.lines
             )
-        )
+        ))
+        return weight.quantize(Decimal('0.01'))  # Quantize to 2 decimal place
 
     def _get_ship_from_address(self):
         """

--- a/shipment.py
+++ b/shipment.py
@@ -322,12 +322,12 @@ class GenerateShippingLabel(Wizard):
         if shipment.allow_label_generation():
             values = {
                 'shipment': shipment.id,
+                'override_weight': shipment.override_weight,
             }
 
         if shipment.carrier:
             values.update({
                 'carrier': shipment.carrier.id,
-                'override_weight': shipment.override_weight,
             })
 
         return values

--- a/shipment.py
+++ b/shipment.py
@@ -139,12 +139,13 @@ class ShipmentOut:
         Returns sum of weight associated with each move line
         """
         weight_uom = self._get_weight_uom()
-        return sum(
+        weight = Decimal(sum(
             map(
                 lambda move: move.get_weight(weight_uom, silent=True),
                 self.outgoing_moves
             )
-        )
+        ))
+        return weight.quantize(Decimal('0.01'))  # Quantize to 2 decimal place
 
     def allow_label_generation(self):
         """


### PR DESCRIPTION
Quantize package_weight to 2 decimal, else Numeric field may result in
   dirty field in tryton client, on client side roundoff.

   Fixed override_weight default in wizard